### PR TITLE
Installing and building pyhawkes on OSX 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ data/gifs/test*.gif
 
 # PyCharm
 .idea/*
+pyhawkes/internals/continuous_time_helpers.c
+pyhawkes/internals/parent_updates.c

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,0 +1,19 @@
+# installing pyhawkes on osx
+
+    # install compiled dependencies
+    brew update
+    brew install clang-omp
+    brew install gsl
+
+    # install gslrandom with OpenMP support
+    CC=clang-omp CXX=clang-omp++ pip install gslrandom
+
+    # install other dependencies
+    pip install -r requirements.txt
+
+    # if you want to develop the library, run:
+    CC=clang-omp python setup.py build_ext --inplace
+    pip install -e .
+
+    # for everyone else, run:
+    CC=clang-omp python setup.py install

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -8,22 +8,22 @@ To install this requires compiling with OpenMP support, but OSX does not come wi
     brew update
     brew install clang-omp
 
-Then, `gslrandom` is a dependency that requires OpenMP, and so to build it with the appropriate C and C++ compiler, which in this case will be `clang-omp` and `clang-omp++`:
+Then, `gslrandom` is a dependency that requires OpenMP as well as a number of other packages included in the `requirements.txt`. To build `gslrandom` requires building it with the appropriate C and C++ compiler, which in this case will be `clang-omp` and `clang-omp++`. However, because it also requires other packages, namely `Cython` and `numpy` we will first install the requirements from `requirements.txt`:
+
+    # install other dependencies
+    pip install -r requirements.txt
+
+Note because `gslrandom` requires a custom set of installation instructions though it is listed in the `requirements.txt` file it is commented out, and therefore is not automatically included in the `pip install` command. To install `gslrandom` we will install `gsl`, which is a non-python specific dependency and then will pip install `gslrandom` using `clang-omp` and `clang-omp++` as our `C` and `C++` compilers.
 
     # install gslrandom with OpenMP support
     brew install gsl
     CC=clang-omp CXX=clang-omp++ pip install gslrandom
 
-All other dependencies are python dependencies accessible through `pip` and the `requirements.txt` file:
-
-    # install other dependencies
-    pip install -r requirements.txt
-
-Depending on whether you want to build a development install or a standard install you will need to use one of the two following sets of commands:
+Your environment should now be setup properly to either build a development or standard version of the library.  Depending on whether you want to build a development install or a standard install you will need to use one of the two following sets of commands:
 
     # if you want to develop the library, run:
     CC=clang-omp python setup.py build_ext --inplace
-    pip install -e .
+    CC=clang-omp pip install -e .
 
     # for a standard install, run:
     CC=clang-omp python setup.py install

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,19 +1,29 @@
 # installing pyhawkes on osx
 
-    # install compiled dependencies
+This is a set of instructions for installing pyhawkes on OSX.
+
+To install this requires compiling with openMP support, but OSX does not come with this support in its default clang. Thus you will need to install clang-omp.
+
+    # install clang with OpenMP support (needed to compile later packages)
     brew update
     brew install clang-omp
-    brew install gsl
+
+Then, gslrandom is a dependency that requires OpenMP, and so to build it with the appropriate C and C++ compiler, which in this case will be clang-omp and clang-omp++.
 
     # install gslrandom with OpenMP support
+    brew install gsl
     CC=clang-omp CXX=clang-omp++ pip install gslrandom
+
+All other dependencies are python dependencies accessible through pip and the requirements.txt file.
 
     # install other dependencies
     pip install -r requirements.txt
+
+Depending on whether you want to build a development install or a standard install you will need to use one of the two following sets of commands
 
     # if you want to develop the library, run:
     CC=clang-omp python setup.py build_ext --inplace
     pip install -e .
 
-    # for everyone else, run:
+    # for a standard install, run:
     CC=clang-omp python setup.py install

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,25 +1,25 @@
-# installing pyhawkes on osx
+# Installing pyhawkes on OSX
 
 This is a set of instructions for installing pyhawkes on OSX.
 
-To install this requires compiling with openMP support, but OSX does not come with this support in its default clang. Thus you will need to install clang-omp.
+To install this requires compiling with OpenMP support, but OSX does not come with this support in its default `clang`. Thus you will need to install `clang-omp`:
 
     # install clang with OpenMP support (needed to compile later packages)
     brew update
     brew install clang-omp
 
-Then, gslrandom is a dependency that requires OpenMP, and so to build it with the appropriate C and C++ compiler, which in this case will be clang-omp and clang-omp++.
+Then, `gslrandom` is a dependency that requires OpenMP, and so to build it with the appropriate C and C++ compiler, which in this case will be `clang-omp` and `clang-omp++`:
 
     # install gslrandom with OpenMP support
     brew install gsl
     CC=clang-omp CXX=clang-omp++ pip install gslrandom
 
-All other dependencies are python dependencies accessible through pip and the requirements.txt file.
+All other dependencies are python dependencies accessible through `pip` and the `requirements.txt` file:
 
     # install other dependencies
     pip install -r requirements.txt
 
-Depending on whether you want to build a development install or a standard install you will need to use one of the two following sets of commands
+Depending on whether you want to build a development install or a standard install you will need to use one of the two following sets of commands:
 
     # if you want to develop the library, run:
     CC=clang-omp python setup.py build_ext --inplace

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This codebase is considerably cleaner than the old CUDA version, and is still
 quite fast with the Cython+OMP extensions and joblib for parallel sampling of
 the adjacency matrix.
 
+For installing on OSX see the [INSTALL_OSX.md](INSTALL_OSX.md) file.
+
 
 More Information
 ===

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython
 numpy
-gslrandom
+#gslrandom
 joblib
 scikit-learn
 pybasicbayes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Cython
+numpy
+gslrandom
+joblib
+scikit-learn
+pybasicbayes
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(name='pyhawkes',
       url='http://www.github.com/slinderman/pyhawkes',
       ext_modules=ext_modules,
       include_dirs=[np.get_include(),],
+      packages=['pyhawkes', 'pyhawkes.internals', 'pyhawkes.utils']
      )


### PR DESCRIPTION
Got this installed today, but OSX requires some finagling to get this working because of the complexities around using `OpenMP`.

Added the `requirements.txt`, made installable by editing the `setup.py`, gave instructions for getting `clang-omp` to compile the files appropriately on OSX (otherwise it uses the builtin `gcc` and `g++` which do not contain OpenMP support).

