### PR TITLE
Correctly importing ModelGibbsSampling from pybasicbayes

### DIFF
--- a/pyhawkes/models.py
+++ b/pyhawkes/models.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.special import gammaln
 from scipy.optimize import minimize
 
-from pybasicbayes.models import ModelGibbsSampling, ModelMeanField
+from pybasicbayes.abstractions import ModelGibbsSampling, ModelMeanField
 from pybasicbayes.util.text import progprint_xrange
 
 from pyhawkes.internals.bias import GammaBias


### PR DESCRIPTION
ModelGibbsSampling is to be imported from "pybasicbayes.abstractions" as pybasicbayes.models do not have that.