### PR TITLE
consistent type with asserts

### DIFF
--- a/pyhawkes/utils/utils.py
+++ b/pyhawkes/utils/utils.py
@@ -40,7 +40,7 @@ def convert_continuous_to_discrete(S, C, dt, T_min, T_max):
         S_dt[:,k] = np.histogram(S[C==k], bins)[0]
 
     assert S_dt.sum() == len(S)
-    return S_dt
+    return S_dt.astype(np.int)
 
 def get_unique_file_name(filedir, filename):
     """


### PR DESCRIPTION
if you want to use the `convert_continuous_to_discrete` function with the rest of the models, such as:
`pyhawkes.models.DiscreteTimeNetworkHawkesModelSpikeAndSlab.add_data()`
it will now scream
>"Data must be a TxK array of event counts"

because of `assert S.dtype == np.int`

this changes the returned type so that it is consistent with the rest of the code